### PR TITLE
Update Ganglion programming docs based on firmware v3 alpha testing feedback

### DIFF
--- a/website/docs/Ganglion/08-Ganglion_Data_Format.md
+++ b/website/docs/Ganglion/08-Ganglion_Data_Format.md
@@ -39,7 +39,9 @@ The cost of this transmission strategy is a reduction in sample resolution, but 
 
 We send ExG samples using either 19 bits or 18 bits. By default, 19-bit samples are sent. When the accelerometer or auxiliary features of the board are used, 18-bit samples are sent to provide room for the accelerometer or auxiliary data in the packet. Different packet ID ranges are used for 19-bit samples and 18-bit samples. This way, the controlling software that is running the decompression algorithm can decompress each packet without having to 'know' what state the system is in.
 
-**IMPORTANT!** Both the 18-bit and 19-bit transmission strategies store the signed bit in the `bit 0` or LSB position!
+:::info
+Both the 18-bit and 19-bit transmission strategies store the signed bit in the `bit 0` or LSB position!
+:::
 
 ### 19-bit Sample Transmission
 
@@ -78,9 +80,14 @@ void OpenBCI_Ganglion::sendCompressedPacket18() {
     }
 
 ```
- 
-**NOTE** that the Ganglion also has the capacity to send user defined `auxData` in the place of accelerometer data.  
-**NOTE** An `n` ASCII command is used to turn on the Ganglion accelerometer. Use an `N` to turn off the accelerometer.
+
+:::note
+The Ganglion also has the capacity to send user defined `auxData` in the place of accelerometer data.
+:::
+
+:::note
+An `n` ASCII command is used to turn on the Ganglion accelerometer. Use an `N` to turn off the accelerometer.
+:::
 
 ## Impedance Testing
 

--- a/website/docs/Ganglion/09-Ganglion_Programming_Tutorial.md
+++ b/website/docs/Ganglion/09-Ganglion_Programming_Tutorial.md
@@ -2,33 +2,35 @@
 id: GanglionProgram
 title: Ganglion Programming Tutorial
 ---
-**Please note, you do NOT need to program the Ganglion in order to use it. All OpenBCI boards ship ready to use out of the box. This guide is for users who want to upload their own firmware to the Ganglion or modify existing firmware.**
+:::tip
+**You do NOT need to program the Ganglion in order to use it. All OpenBCI boards ship ready to use out of the box. This guide is for users who want to upload their own firmware to the Ganglion or modify existing firmware.**
+:::
 
-This guide will walk you through how to update your Ganglion firmware. Downloading the latest binary and Over The Air programming (OTA) makes updating the Ganglion a breeze with a mobile device. If you want to compile the code in Arduino continue to the [Building From Source](#ganglion-programming-tutorial-building-from-source) portion of the guide.
-
-To program the Ganglion over the air, keep reading. To program using hardware, refer to the [last section.](#ganglion-programming-tutorial-setting-up-to-program-ganglion-using-hardware)
+This guide will walk you through how to update your Ganglion firmware. Downloading the latest binary and Over The Air programming (OTA) makes updating the Ganglion a breeze with a mobile device. If you want to compile the code in Arduino, continue to the [Building From Source](#ganglion-programming-tutorial-building-from-source) portion of the guide.
 
 ## Download The Latest Builds
 
 - [OpenBCI GUI](https://github.com/OpenBCI/OpenBCI_GUI/releases)  
-- [Ganglion Firmware v3.0.0](https://github.com/OpenBCI/OpenBCI_Ganglion_Library/releases/download/v3.0.0/DefaultGanglion3.0.1.zip)
+- [Ganglion Firmware v3.0.0](https://github.com/OpenBCI/OpenBCI_Ganglion_Library/releases/download/v3.0.0/DefaultGanglion3.0.0.zip)
 
-If you prefer to use the precompiled binaries, jump down to [setup your mobile device for OTA programming](#setup-mobile-device-for-ota-programming) to continue.
+If you are planning to program your Ganglion using the precompiled binaries, jump down to [Setup Mobile Device For OTA Programming](#setup-mobile-device-for-ota-programming) section to continue.
 
 ## Building From Source
 
-The Simblee (website discontinued) radio module that is at the heart of the Ganglion board offers the ability to reprogram Over The Air `OTA`. The method for doing this in a nutshell is:  
+The Simblee (website discontinued) radio module that is at the heart of the Ganglion board offers the ability to reprogram Over The Air (OTA). The method for doing this in a nutshell is:  
 
-1.  Create new Ganglion firmware, or modify existing code in Arduino IDE
-2.  Generate a compiled HEX file in the Arduino IDE
-3.  Compress it into a ZIP with some other important files
-4.  Transfer the ZIP file to your phone or tablet
+1.  Create new Ganglion firmware, or modify the existing code in the Arduino IDE
+2.  Generate a compiled binary in the Arduino IDE
+3.  Compress it into a `.zip` archive with some other important files
+4.  Transfer the `.zip` archive to your phone or tablet
 5.  Connect your phone or tablet to the Ganglion
-6.  Upload new code Over The Air
+6.  Upload new code
 
-The following tutorials will get your computer and the Arduino IDE set up to create the correct ZIP file, and also show how to use your phone or tablet to upload new code to the Ganglion. This guide will also teach you how to upload code to your ganglion for the first time.
+The following instructions will get your computer and the Arduino IDE set up to create the correct `.zip` archive and show how to use your phone or tablet to upload new code to the Ganglion.
 
-**_IMPORTANT: Ganglions shipped prior to February 27, 2017 will NOT program Over The Air for the first time! If you purchased your Ganglion prior to 2/27/17, Please follow the instructions below up till How to create an OTA File and read the instructions the bottom of this page to program your Ganglion for the first time._**
+:::caution
+Ganglions shipped prior to February 27, 2017 will NOT program Over The Air (OTA) for the first time! If you purchased your Ganglion prior to this date, please follow the instructions in the [Program Ganglion Using Hardware](#program-ganglion-using-hardware) section to program your Ganglion for the first time.
+:::caution
 
 ### What You Need
 
@@ -36,7 +38,9 @@ The following tutorials will get your computer and the Arduino IDE set up to cre
 -   [Ganglion Library Firmware](https://github.com/OpenBCI/OpenBCI_Ganglion_Library)
 -   [Wifi Master Library Firmware](https://github.com/OpenBCI/OpenBCI_Wifi_Master_Library)
 
-**IMPORTANT** Be sure to clone the repositories directly to your [Arduino libraries folder](https://docs.arduino.cc/software/ide-v1/tutorials/installing-libraries#manual-installation).
+:::info
+Be sure to clone the repositories directly to your [Arduino libraries folder](https://docs.arduino.cc/software/ide-v1/tutorials/installing-libraries#manual-installation). Alternatively, add the zipped libraries by navigating to `Sketch -> Include Library -> Add .ZIP Library...` and selecting the downloaded archives.
+:::
 
 ### Add the Ganglion via Board Manager
 
@@ -53,24 +57,24 @@ https://openbci-simblee.s3.amazonaws.com/package_simblee_index.json
 
 ### Select DefaultGanglion.ino from Examples
 
-In the Arduino IDE go to `File -> Examples -> OpenBCI_Ganglion_Library -> DefaultGanglion` which will open the Ganglion firmware source code. If you can't see `OpenBCI_Ganglion_Library` then verify `Ganglion` is selected as board type.
-
-**NOTE - You must upload ONLY the `DefaultGanglion` Sketch!**
+In the Arduino IDE go to `File -> Examples -> OpenBCI_Ganglion_Library -> DefaultGanglion`. This will open the Ganglion firmware source code sketch. If you can't see `OpenBCI_Ganglion_Library` then verify `Ganglion` is selected as board type.
 
 ### Create OTA File
 
-To create the OTA files, simply select `Export compiled Binary` from the `Sketch` menu. The Arduino IDE will take a few moments, and the IDE will create the `.zip` file you need for OTA **_in the sketch folder_** right beside your sketch.
+To create the OTA files, first ensure your sketch is saved by navigating to `File -> Save`. Arduino may notify you that your sketch is read-only in which case you will need to select a new location to save it. Next, select `Sketch -> Export compiled Binary`. The Arduino IDE will take a few moments, and the IDE will create the `.zip` file you need for OTA in the sketch folder right beside where you saved your sketch.
 
 ## Setup Mobile Device For OTA Programming
 
-The Simblee is designed around a Nordic Semiconductor [nRF51822](http://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF51822), and so we need to use the Nordic nRF apps to do the actual Over-The-Air stuff. Here's what you will need for this tutorial:
+The Simblee is designed around a Nordic Semiconductor [nRF51822](http://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF51822). We use several apps that support the nRF51822 to perform the OTA update.
 
 ### Install Applications
 
-#### iPhone
+Install both of the applications listed below for your mobile device's operating system.
 
--   [nRF Toolbox App](https://apps.apple.com/us/app/nrf-toolbox/id820906058)
+#### iOS
+
 -   [Lightblue Explorer App](https://apps.apple.com/us/app/lightblue/id557428110)
+-   [nRF Connect App](https://apps.apple.com/us/app/nrf-connect-for-mobile/id1054362403)
 
 #### Android
 
@@ -79,7 +83,7 @@ The Simblee is designed around a Nordic Semiconductor [nRF51822](http://www.nord
 
 ### Verify Ganglion Version
 
-Turn on your Ganglion, and turn on your phone's bluetooth Then open the Lightblue / nRF Connect app. The app will open and show you what Bluetooth Peripherals are nearby. The device may either show up as `Ganglion`, `Simblee`, or `DfuTarg` depending on your OS and Ganglion firmware version. Tap the Ganglion peripheral, and the app will connect to and interrogate it.  
+Turn on your Ganglion and turn on your phone's Bluetooth. Next, open the Lightblue (iOS) / nRF Connect (Android) app. The app will show you what Bluetooth peripherals are nearby. Your Ganglion may show up as either `Ganglion`, `Simblee`, or `DfuTarg` depending on your OS and firmware version. Tap the Ganglion peripheral, and the app will connect to and interrogate it.  
 
 In the Device Information, you will find the following:
 
@@ -89,22 +93,38 @@ In the Device Information, you will find the following:
 -   Firmware Revision String
 -   Software Revision String
 
-You should see `openbci.com` as the Manufacturer, `Ganglion` as the Model Number, and `x.x.x` as the **Software Revision String**. The Hardware and Firmware versions are generated by the Simblee itself.  
+You should see `openbci.com` as the Manufacturer, `Ganglion` as the Model Number, and `x.x.x` as the **Software Revision String**. 
 
-**IMPORTANT - If the Software Revision String is earlier than 1.1.1 you _cannot do OTA_ until you follow the Hardware Upload Tutorial at the bottom of this page.**  
+:::caution
+If the Software Revision String is earlier than `1.1.1`, then you cannot perform OTA updates until you follow the instructions in the [Program Ganglion Using Hardware](#program-ganglion-using-hardware) section.
+:::
 
 ### Uploading the Firmware
 
-1. Transfer the `.zip` file from your Arduino Sketch folder to your phone (e.g. via email, Dropbox, Google Drive, ...)
-2. Start the nRF Toolbox app and select the `Device Firmware Update` tool. Tap the `Select` button, and select the file `.zip` file you moved to your phone.
-3. Select the device identified [above](#verify-ganglion-version).
+Before completing these steps, transfer the `.zip` file from your Arduino Sketch folder to your phone (e.g. via email, Dropbox, or Google Drive).
+
+#### iOS
+
+1. Open the nRF Connect app and connect to the Ganglion. Use the name identified [above](#verify-ganglion-version).
+2. After connecting, select `DFU` from the list of tabs at the top of the screen.
+3. Click the `Open Document Picker` button at the bottom of the screen.
+4. Select the `.zip` file you moved to your iOS device.
+5. After loading the `.zip` archive, press the `Start`` button to upload the firmware.
+
+#### Android
+
+1. Start the nRF Toolbox app and select the `Device Firmware Update` tool. 
+2. Tap the `Select` button, and select the file `.zip` file you moved to your Android device.
+3. Select the Ganglion device identified [above](#verify-ganglion-version).
 4. Start the upload.
 
-**IMPORTANT - Do not turn off your device while the firmware upload is in progress.**
+:::danger
+Do not turn off your device while the firmware upload is in progress.
+:::
 
-## Setting up to Program Ganglion Using Hardware
+## Program Ganglion Using Hardware
 
-Older Ganglions (pre-2017) could only be programmed using hardware first, then over the air. Newer Ganglions can be programmed OTA or using hardware.
+Older Ganglions (pre-2017) must be programmed using hardware before OTA updates can be performed. Newer Ganglions can be programmed either OTA or using hardware.
 
 ### What You Need
 
@@ -115,24 +135,25 @@ Older Ganglions (pre-2017) could only be programmed using hardware first, then o
 
 ![FTDI Breakout](../assets/ThirdPartyImages/FTDI_Friend.jpg)
 ![Capacitor](../assets/GanglionImages/caps.jpg)
+
+In this example, we use the [Adafruit FTDI Friend](https://www.adafruit.com/products/284). You can use any FTDI breakout, as long as it uses **only 3V for logic levels**. If you go to Adafruit to purchase one, you can also pick up some [jumper wires](https://www.adafruit.com/products/758), and [0.1uF Capacitors](https://www.adafruit.com/products/753) as well.  
+
+### Wiring
+
+The 0.1uF capacitor needs to be in between the `RESET` pin of the Ganglion and the `RTS` pin of the FTDI breakout. See the image below for a description of the required pin connections.
+
 ![Ganglion Pins Connection](../assets/GanglionImages/ganglion_ftdi-connection.jpeg)
 
-For this tutorial, I will use the [Adafruit FTDI Friend](https://www.adafruit.com/products/284). You can use any FTDI breakout, as long as it uses **only 3V for logic levels**. If you go to Adafruit to purchase one, you can also pick up some [jumper wires](https://www.adafruit.com/products/758), and [0.1uF Capacitors](https://www.adafruit.com/products/753) as well.  
+:::danger
+The Ganglion is a 3V device! You must never connect a voltage source higher than 3V to any of the pins.
+:::
 
-**IMPORTANT NOTE: THE GANGLION IS A 3V DEVICE! YOU MUST NEVER CONNECT ANY HIGHER VOLTAGE SOURCE TO ANY OF THE PINS!**  
+### Set Up Arduino
 
-The 0.1uF capacitor needs to be in between the `RESET` pin of the Ganglion and the `RTS` pin of the FTDI breakout.
+Follow the guide at the top of this page from the [Building From Source](#building-from-source) section to the [Create an OTA File](#create-ota-file) section. Then continue to the [upload](#upload) section.
 
-### Set Up Arduino to Program Your Ganglion
+### Upload
 
-Follow the guide at the top of this page from [Building From Source](#building-from-source) all the way down till [Create an OTA File](#create-ota-file), then come back here.
-
-### Plug in Dongle or FTDI Friend and Select Serial Port
-
-Now is a good time to plug your Dongle in and power up the Ganglion.
-
-Select the correct serial port from the `Tools > Port` menu for your OpenBCI Dongle or FTDI friend. If you don't know which port is correct, try unplugging the device and noting which port disappears from the menu. Plugging the device back in should cause the port to reappear.
-
-### Verify Wire Connections and Press Upload
-
-With your wires all connected correctly, you should be able to click the `Upload` button and successfully re-program the Ganglion. Now you're ready to do OTA Programming!
+1. Plug your dongle or FTDI Friend in and power up the Ganglion.
+2. Select the correct serial port from the `Tools > Port` menu for your OpenBCI Dongle or FTDI friend. If you don't know which port is correct, try unplugging the device and noting which port disappears from the menu. Plugging the device back in should cause the port to reappear.
+3. With your wires all connected correctly, you should be able to click the `Upload` button and successfully re-program the Ganglion. Now you're ready to [deploy OTA updates](#create-ota-file)!

--- a/website/docs/Ganglion/09-Ganglion_Programming_Tutorial.md
+++ b/website/docs/Ganglion/09-Ganglion_Programming_Tutorial.md
@@ -28,9 +28,9 @@ The Simblee (website discontinued) radio module that is at the heart of the Gang
 
 The following instructions will get your computer and the Arduino IDE set up to create the correct `.zip` archive and show how to use your phone or tablet to upload new code to the Ganglion.
 
-:::caution
+:::important
 Ganglions shipped prior to February 27, 2017 will NOT program Over The Air (OTA) for the first time! If you purchased your Ganglion prior to this date, please follow the instructions in the [Program Ganglion Using Hardware](#program-ganglion-using-hardware) section to program your Ganglion for the first time.
-:::caution
+:::
 
 ### What You Need
 
@@ -95,7 +95,7 @@ In the Device Information, you will find the following:
 
 You should see `openbci.com` as the Manufacturer, `Ganglion` as the Model Number, and `x.x.x` as the **Software Revision String**. 
 
-:::caution
+:::important
 If the Software Revision String is earlier than `1.1.1`, then you cannot perform OTA updates until you follow the instructions in the [Program Ganglion Using Hardware](#program-ganglion-using-hardware) section.
 :::
 

--- a/website/docs/Ganglion/09-Ganglion_Programming_Tutorial.md
+++ b/website/docs/Ganglion/09-Ganglion_Programming_Tutorial.md
@@ -6,12 +6,12 @@ title: Ganglion Programming Tutorial
 **You do NOT need to program the Ganglion in order to use it. All OpenBCI boards ship ready to use out of the box. This guide is for users who want to upload their own firmware to the Ganglion or modify existing firmware.**
 :::
 
-This guide will walk you through how to update your Ganglion firmware. Downloading the latest binary and Over The Air programming (OTA) makes updating the Ganglion a breeze with a mobile device. If you want to compile the code in Arduino, continue to the [Building From Source](#ganglion-programming-tutorial-building-from-source) portion of the guide.
+This guide will walk you through how to update your Ganglion firmware. Downloading the latest binary and Over The Air programming (OTA) makes updating the Ganglion a breeze with a mobile device.
 
 ## Download The Latest Builds
 
 - [OpenBCI GUI](https://github.com/OpenBCI/OpenBCI_GUI/releases)  
-- [Ganglion Firmware v3.0.0](https://github.com/OpenBCI/OpenBCI_Ganglion_Library/releases/download/v3.0.0/DefaultGanglion3.0.0.zip)
+- [Ganglion Firmware](https://github.com/OpenBCI/OpenBCI_Ganglion_Library/releases/download/v3.0.0/DefaultGanglion3.0.0.zip)
 
 If you are planning to program your Ganglion using the precompiled binaries, jump down to [Setup Mobile Device For OTA Programming](#setup-mobile-device-for-ota-programming) section to continue.
 
@@ -44,7 +44,7 @@ Be sure to clone the repositories directly to your [Arduino libraries folder](ht
 
 ### Add the Ganglion via Board Manager
 
-1. Navigate to `File -> Preferences`
+1. Navigate to `Preferences`
 2. Paste the following URL into the `Additional Boards Manager URLs` field
 
 ```
@@ -61,7 +61,7 @@ In the Arduino IDE go to `File -> Examples -> OpenBCI_Ganglion_Library -> Defaul
 
 ### Create OTA File
 
-To create the OTA files, first ensure your sketch is saved by navigating to `File -> Save`. Arduino may notify you that your sketch is read-only in which case you will need to select a new location to save it. Next, select `Sketch -> Export compiled Binary`. The Arduino IDE will take a few moments, and the IDE will create the `.zip` file you need for OTA in the sketch folder right beside where you saved your sketch.
+To create the OTA files, first ensure your sketch is saved. Arduino may notify you that your sketch is read-only in which case you will need to select a new location to save it. Next, select `Sketch -> Export compiled Binary`. The Arduino IDE will take a few moments, and the IDE will create the `.zip` file you need for OTA in the sketch folder right beside where you saved your sketch.
 
 ## Setup Mobile Device For OTA Programming
 
@@ -101,7 +101,9 @@ If the Software Revision String is earlier than `1.1.1`, then you cannot perform
 
 ### Uploading the Firmware
 
-Before completing these steps, transfer the `.zip` file from your Arduino Sketch folder to your phone (e.g. via email, Dropbox, or Google Drive).
+Before completing this step, you should either download the [precompiled binaries](https://github.com/OpenBCI/OpenBCI_Ganglion_Library/releases/download/v3.0.0/DefaultGanglion3.0.0.zip) or compile the firmware from source as described in the [Building from Source](#building-from-source) section.
+
+Transfer this `.zip` file to your phone (e.g. via email, Dropbox, or Google Drive).
 
 #### iOS
 


### PR DESCRIPTION
- Updated iOS documentation based on feedback from @tharun-OpenBCI.
- Fixed grammatical problems and improved clarity in some sections.
- Fixed link to pre-compiled firmware binary.
- Replaced "info" and "important" statements with [Docusaurus Admonitions](https://docusaurus.io/docs/markdown-features/admonitions).