### PR TITLE
Recommend only Arduino 1.8.x for Ganglion programming

### DIFF
--- a/website/docs/Ganglion/09-Ganglion_Programming_Tutorial.md
+++ b/website/docs/Ganglion/09-Ganglion_Programming_Tutorial.md
@@ -115,7 +115,7 @@ The following instructions will get your computer and the Arduino IDE set up to 
 
 ### What You Need
 
--   [Arduino IDE v1.8.19](https://www.arduino.cc/en/software) or newer
+-   [Arduino IDE v1.8.x](https://www.arduino.cc/en/software)
 -   [Ganglion Library Firmware](https://github.com/OpenBCI/OpenBCI_Ganglion_Library)
 -   [Wifi Master Library Firmware](https://github.com/OpenBCI/OpenBCI_Wifi_Master_Library)
 

--- a/website/docs/Ganglion/09-Ganglion_Programming_Tutorial.md
+++ b/website/docs/Ganglion/09-Ganglion_Programming_Tutorial.md
@@ -16,7 +16,7 @@ This guide will walk you through how to update your Ganglion firmware. Downloadi
 ## Download The Latest Builds
 
 - [OpenBCI GUI](https://github.com/OpenBCI/OpenBCI_GUI/releases)  
-- [Ganglion Firmware](https://github.com/OpenBCI/OpenBCI_Ganglion_Library/releases/download/v3.0.1/DefaultGanglion3.0.1.zip)
+- [Ganglion Firmware](https://github.com/OpenBCI/OpenBCI_Ganglion_Library/releases)
 
 ## Ganglion OTA Firmware Programming
 


### PR DESCRIPTION
Arduino 2.x.x will not work for Ganglion programming as identified by @evaesteban in https://github.com/OpenBCI/OpenBCI_Ganglion_Library/pull/26.