### PR TITLE
Update sidebar "FAQ" and "Policies" dropdown location to bottom of sidebar

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,22 +1,7 @@
 {
   "docs": {
       "Welcome to OpenBCI": ["Welcome"],
-      "FAQ": [
-        "FAQ/FAQLanding",
-        "FAQ/GenFAQ",
-        "FAQ/HowProductsGoTogether",
-        "FAQ/HardFAQ",
-        "FAQ/PaymentFAQ",
-        "FAQ/ShippingFAQ",
-        "FAQ/DocsUpdate"
-      ],
-      "Policies": [
-        "FAQ/Cookie",
-        "FAQ/Privacy",
-        "FAQ/Returns",
-        "FAQ/Liability",
-        "FAQ/Conduct"
-      ],
+
       "Getting Started": [
             "GettingStarted/GettingStartedLanding",
             {
@@ -219,7 +204,22 @@
               "Examples/EEGProjects/MotorImagery"
             ]
           }
+        ],
+        "FAQ": [
+          "FAQ/FAQLanding",
+          "FAQ/GenFAQ",
+          "FAQ/HowProductsGoTogether",
+          "FAQ/HardFAQ",
+          "FAQ/PaymentFAQ",
+          "FAQ/ShippingFAQ",
+          "FAQ/DocsUpdate"
+        ],
+        "Policies": [
+          "FAQ/Cookie",
+          "FAQ/Privacy",
+          "FAQ/Returns",
+          "FAQ/Liability",
+          "FAQ/Conduct"
         ]
-        
     }
   }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,30 +1,21 @@
 {
   "docs": {
       "Welcome to OpenBCI": ["Welcome"],
-    "FAQ": [
-          {
-            "type": "category",
-            "label": "FAQ",
-            "items": [
-                "FAQ/FAQLanding",
-                "FAQ/GenFAQ",
-                "FAQ/HowProductsGoTogether",
-                "FAQ/HardFAQ",
-                "FAQ/PaymentFAQ",
-                "FAQ/ShippingFAQ",
-                "FAQ/DocsUpdate"
-            ]
-          }, {
-            "type": "category",
-            "label": "Policies",
-            "items": [
-                "FAQ/Cookie",
-                "FAQ/Privacy",
-                "FAQ/Returns",
-                "FAQ/Liability",
-                "FAQ/Conduct"
-            ]
-          }
+      "FAQ": [
+        "FAQ/FAQLanding",
+        "FAQ/GenFAQ",
+        "FAQ/HowProductsGoTogether",
+        "FAQ/HardFAQ",
+        "FAQ/PaymentFAQ",
+        "FAQ/ShippingFAQ",
+        "FAQ/DocsUpdate"
+      ],
+      "Policies": [
+        "FAQ/Cookie",
+        "FAQ/Privacy",
+        "FAQ/Returns",
+        "FAQ/Liability",
+        "FAQ/Conduct"
       ],
       "Getting Started": [
             "GettingStarted/GettingStartedLanding",


### PR DESCRIPTION
Sidebar had redundancies in "FAQ" dropdown. 

<img width="288" alt="Screen Shot 2024-05-21 at 5 32 37 PM" src="https://github.com/OpenBCI/Documentation/assets/93345187/39325bfb-a9e2-4209-ac58-f39c0e690c7b"> Please see double "FAQ" drop downs. 


Deleted topmost "FAQ" dropdown and moved second "FAQ" dropdown and "Policies" dropdown to bottom of page for better organization. 
