### PR TITLE
fix-outdated-info-on-networking-widget

### DIFF
--- a/website/docs/ForDevelopers/01-SoftwareDevelopment.md
+++ b/website/docs/ForDevelopers/01-SoftwareDevelopment.md
@@ -18,7 +18,7 @@ BrainFlow is written in C++ and then exported to a handful of languages. This cu
 
 GUI v5.0+ uses the BrainFlow-Java package. When starting a new project with OpenBCI hardware for the first time, it is important to check that you can connect the hardware properly, [depending on your biosensing setup](ForDevelopers/00-ForDevelopersLanding.md#biosensing-setups). 
 
-We recommend using the GUI to start your project and check signals before moving towards full integration. Furthermore, we recommend using the GUI's Networking Widget to stream data for proof-of-concept via UDP, LSL, OSC, or Serial. This allows you to visualize real-time and playback data in the GUI while modifying your application in a separate IDE.
+We recommend using the GUI to start your project and check signals before moving towards full integration. Furthermore, we recommend using the [Brainflow Streamer](https://docs.openbci.com/Software/OpenBCISoftware/GUIDocs/#gui-to-external-process) in the GUI to stream data for proof-of-concept. This allows you to visualize real-time and playback data in the GUI while modifying your application in a separate IDE.
 
 Once proof-of-concept is achieved, it's appopriate to consider integrating the OpenBCI board directly into your project using one of the BrainFlow bindings, found below. The GUI can still be used at any time to check signals, make recordings, and stream live data.
 

--- a/website/docs/Software/OpenBCISoftware/01-OpenBCI_GUI.md
+++ b/website/docs/Software/OpenBCISoftware/01-OpenBCI_GUI.md
@@ -221,9 +221,6 @@ This feature allows more advanced users to connect to OpenBCI boards using an ex
 
 Similarly, you can reverse this process by using the BrainFlow Streamer set to "Network" and specifying the IP address and port there. The data sent out from the GUI is unfiltered. Here is the [official BrainFlow Documentation for Streaming Board](https://brainflow.readthedocs.io/en/stable/SupportedBoards.html?highlight=streaming%20board#streaming-board).
 
-:::tip Recommendation
-This method can be more reliable and quicker to implement than sending Time Series data out from the Networking Widget over UDP, LSL, or OSC!
-:::
 
 ![BrainFlow Streamer over Network Option](../../assets/SoftwareImages/OpenBCISoftware/OpenBCI_GUI-BrainFlowStreamerNetworkSetting_Screenshot.png)
 


### PR DESCRIPTION
According to @Andrey1994, in our conversation on the OpenBrainTalk Slack, the networking widget does not work with brainflow. 

