### PR TITLE
Added OS-specific direct download links in OpenBCI_GUI.md header

### DIFF
--- a/website/docs/Software/OpenBCISoftware/01-OpenBCI_GUI.md
+++ b/website/docs/Software/OpenBCISoftware/01-OpenBCI_GUI.md
@@ -3,6 +3,13 @@ id: GUIDocs
 title: The OpenBCI GUI
 ---
 
+<img src="https://cdn.sanity.io/images/qs7k8l6f/production/7a7d6d98d55922d2ed0b1f395453ec1d9ca184a4-725x725.png" width="18" height="18"></img>&nbsp;
+<big><big><strong><a href="https://github.com/OpenBCI/OpenBCI_GUI/releases/download/v6.0.0-beta.1/openbcigui_v6.0.0-beta.1_macosx.dmg">Download Mac version here</a></strong></big></big><br></br>
+<img src="https://cdn.sanity.io/images/qs7k8l6f/production/c8eaf6cbf6788dc901cbc0ccb503ef9fe3a17e7c-725x725.png" width="18" height="18"></img>&nbsp;
+<big><big><strong><a href="https://github.com/OpenBCI/OpenBCI_GUI/releases/download/v6.0.0-beta.1/openbcigui_v6.0.0-beta.1_macosx.dmg">Download Windows version here</a></strong></big></big><br></br>
+<img src="https://cdn.sanity.io/images/qs7k8l6f/production/2f38b71ce97a140c2fc90a3e27f727240523b59d-100x100.png" width="18" height="18"></img>&nbsp;
+<big><big><strong><a href="https://github.com/OpenBCI/OpenBCI_GUI/releases/download/v6.0.0-beta.1/openbcigui_v6.0.0-beta.1_macosx.dmg">Download Linux version here</a></strong></big></big><br></br>
+
 ![image](../../assets/SoftwareImages/OpenBCISoftware/GUI-V4-Screenshot.jpg)
 
 The OpenBCI GUI is OpenBCI's powerful software tool for visualizing, recording, and streaming data from the OpenBCI Boards. Data can be displayed in live-time, played back, saved to your computer in .txt or .bdf/.edf format, as well as streamed in live-time to third-party software such as MATLAB.


### PR DESCRIPTION
This PR addresses [Issue #230](https://github.com/OpenBCI/Documentation/issues/230) by making the OpenBCI GUI download links also appear in the header of the OpenBCI_GUI.md markdown page.

Changes Implemented:
- Added 3 direct download URLs to OS-specific versions of the OpenBCI GUI program
- Each URL has an OS-specific icon and an appropriate title to help users determine which version to download
- Utilized HTML-style components to format the icon with the image, I can revert to keep in style with the docusaurus markdown-style syntax

Possible Technical Debt:
- The download links referenced are hard links to the specific version of OpenBCI GUI currently available (v6.0.0-beta.1), and I assume the link will be outdated when a new version is released. I can instead link directly to the overall downloads page or use another URL that points to the latest release version
- A heading title for the download links may also be needed

