### PR TITLE
Fixes #188: Add Marker Widget section to GUI Widget Guide

### DIFF
--- a/website/docs/Software/OpenBCISoftware/02_GUI_Widget_Guide.md
+++ b/website/docs/Software/OpenBCISoftware/02_GUI_Widget_Guide.md
@@ -273,6 +273,30 @@ Open Sound Control is a protocol for networking sound synthesizers, computers, a
 
 OSC works with MaxMSP, PureData, and Resolume.
 
+## Marker
+
+The marker widget allows users to insert event markers into their data stream while recording in the OpenBCI GUI. These markers are useful for tracking specific events or experimental triggers during EEG, EMG, or ECG data collection.
+
+### How to Add Markers
+
+There are three ways to insert a marker into the data stream:
+
+1. **UI Buttons:** Click one of the marker buttons within the GUI to insert a marker manually. You can adjust the vertical scale inside the widget to increase or decrease the number of available marker buttons.
+2. **Keyboard Shortcuts:** Use the following predefined keyboard shortcuts to add markers quickly:
+      * Z, X, C, V → Insert markers 1, 2, 3, and 4.
+      * Shift + Z, Shift + X, Shift + C, Shift + V → Insert markers 5, 6, 7, and 8.
+3. **UDP Input:** The GUI can receive markers from an external program over a network using UDP (User Datagram Protocol). This allows markers to be inserted remotely from another application.
+
+### Using UDP to Send Markers
+
+The GUI listens for **single float values** sent over UDP. These values will be recorded as markers in both the **GUI CSV file** and **BrainFlow CSV file**.
+
+- The UDP receiver listens for data on the specified IP address and port. These can be adjusted using the **Receive IP** and **Receive Port** fields inside the Marker Widget.
+- When an external application sends a single float value, the GUI records that value as a marker.
+- Updating the IP address or port in the GUI will automatically restart the UDP listener.
+
+Here is an **[example Python script in the GUI Networking Test Kit](https://github.com/OpenBCI/OpenBCI_GUI/blob/db1cbc580980f725c85f6d46ec98e2f7cefb9851/Networking-Test-Kit/UDP/udp_send_marker.py)** that sends markers over UDP to the OpenBCI GUI.
+
 ## Cyton Signal Widget
 
 Use this widget to check the signal quality of attached electrodes. There are two modes for this widget: Impedance and Live. You will find a description of each mode below along with screenshots. _For now, a placeholder image of the headplot with default electrode positions is displayed on the right side of this widget. We will be updating this in the next major version of the GUI._


### PR DESCRIPTION
This change addresses [Issue #188](https://github.com/OpenBCI/Documentation/issues/188).

## Changes:
- Added a new Marker Widget section to the GUI Widget Guide.
- Explained the three ways to insert markers: UI buttons, keyboard shortcuts, and UDP input. 
- Documented how to configure UDP marker input, including IP/Port settings.
- Provided a link to the [example Python script](https://github.com/OpenBCI/OpenBCI_GUI/blob/db1cbc580980f725c85f6d46ec98e2f7cefb9851/Networking-Test-Kit/UDP/udp_send_marker.py) in the Networking Test Kit.

## Notes
- I didn’t update the OpenBCI GUI Networking Guide since I don’t have access to the Google Docs file.
- Can add images/GIFs to make this information even more clear
- This page (GUI Widget Guide) uses the [Github Releases page](https://github.com/OpenBCI/OpenBCI_GUI/releases) for the GUI download link, whereas the OpenBCI GUI page uses the [website download link](https://openbci.com/downloads). Should we standardize this and use the website link here as well?