### PR TITLE
Fix raw github image links

### DIFF
--- a/website/docs/AddOns/Headwear/03-Headband_Tutorial.md
+++ b/website/docs/AddOns/Headwear/03-Headband_Tutorial.md
@@ -11,32 +11,32 @@ This tutorial will guide you through setting up your headband kit! Please read t
 
 #### Each kit includes:
 
-<img src="https://github.com/OpenBCI/Documentation/blob/master/website/docs/assets/headband-images/headband_kit_full.png?raw=true" width="30%" />
+![Headband Kit](../../assets/headband-images/headband_kit_full.png)
 
 1.  Pair of Ear-clip electrodes
 2.  Dry comb snap silver-silver chloride coated EEG electrodes
 3.  Dry flat snap silver-silver chloride coated EEG electrodes
-4.  Pack of snap electrode cables 
+4.  Pack of snap electrode cables
 5.  One adjustable headband strap
 6.  clip to attach your board case to the headband strap (in headband kit 0.5 meter variant)
 
-The comb and flat snap electrodes snap in and out of the cables easily. No tools needed. 
+The comb and flat snap electrodes snap in and out of the cables easily. No tools needed.
 
 All electrode wires end in a 0.1" female header termination compatible with OpenBCI biosensing boards (Ganglion, Cyton, and CytonDaisy).
 
 #### 10-20 Internationally Accepted EEG Node Placement
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/headband-images/10-20%20Placement.jpg?raw=true" width="30%" />
+![10-20 Placement ](../../assets/headband-images/10-20%20Placement.jpg)
 
 The flat snap electrodes facilitate multiple frontal cortex measurements (F7, AF7, Fp1, Fpz, Fp2, AF8, F8). The comb snap electrodes will allow measurement at the FT7/FT8, T7/T8, TP7/TP8, P7/P8, PO7/PO8, O1/O2, and Oz nodes, depending where on the adjustable strap you place the electrodes. This kit is intended to provide up to eight channels of EEG data when paired with the Cyton 8-channel board. If you want 16-channels, purchase two headband kits and pair them with the CytonDaisy 16-channel board.
 
 ## Headband-Ganglion Tutorial
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/headband-images/Headband_Ganglion_Front.JPG?raw=true" width="30%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/headband-images/Headband_Ganglion_Front.JPG" width="30%" />
 
 The Ganglion board supports four channels of EEG/EMG/EEG input and streams data over bluetooth. In this tutorial we will show you how to obtain two frontal lobe measurements and two temporal lobe measurements using the four channels of the Ganglion and stream the data over bluetooth!
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/headband-images/Ganglion.JPG?raw=true" width="30%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/headband-images/Ganglion.JPG" width="30%" />
 
 #### Battery
 
@@ -46,16 +46,15 @@ All OpenBCI boards ship with a compact, rechargeable lithium polymer 3.7V batter
 
 Fully charge the Lithium Polymer Battery, until the charger's indicator LED turns green
 
-
 #### Hardware
 
 Your Ganglion may have shipped with orange protective cellophane over switches sw1 - sw4. After you've peeled the protective layer off, and flipped the switches to **down** position, the Ganglion board will be in EEG mode (shown below).
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/headband-images/Ganglion_Switch.JPG?raw=true" width="30%" />
+![Ganglion Switch](../../assets/headband-images/Ganglion_Switch.JPG)
 
 Optional: see the [Ganglion Hardware page](../../Ganglion/02-Ganglion.md#inverting-input-select-switches) for a detailed explanation of why we flip the four channel switches to **down**.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/headband-images/Ganglion_Headband_Pins.JPG?raw=true" width="30%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/headband-images/Ganglion_Headband_Pins.JPG" width="30%" />
 
 **Steps**
 
@@ -77,7 +76,7 @@ Optional: see the [Ganglion Hardware page](../../Ganglion/02-Ganglion.md#inverti
 
 The placement of nodes on the headband is best represented in the following image:
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/headband-images/EEG%20Nodes_Updated_Ganglion.png?raw=true" width="30%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/headband-images/EEG%20Nodes_Updated_Ganglion.png" width="30%" />
 
 In this diagram, the red circles represent areas where flat electrodes can be placed, and the blue circles represent areas where comb electrodes can be placed. This placement is ultimately up to you, and the areas that you wish to record. However, a general suggestion for standard electrode placement is outlined in yellow.
 
@@ -86,7 +85,6 @@ To attach the electrodes to the headband:
 1.  Place the cable head on the rough side of the velcro
 2.  Place the electrode on the soft side of the velcro
 3.  Snap the two pieces together, with the velcro in between, to secure them.
-
 
 To attach the OpenBCI board onto the headband (for 0.5 meter variants):
 
@@ -103,13 +101,13 @@ Now that you've finished with the hardware set-up, the next step is to set up th
 
 Once you've downloaded the GUI zip file per tutorial instructions, fire up the GUI [as shown in this YouTube video!](http://www.youtube.com/watch?v=NAM6eOA4a8Y)
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/headband_gui_ganglion.jpeg?raw=true" width="30%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/headband_gui_ganglion.jpeg" width="30%" />
 
 Notice the sharp peak-trough-peak wave behavior in the upper left time series window of the GUI. The first peak corresponds with the initiation of an eye blink, the trough immediately after shows a dip in alpha brain waves that syncs to the eye's closing for a fraction of a second! The peak immediately **after** the trough corresponds to the brain signals to the eyelid to reopen, thus concluding the blink cycle.
 
 The band power window in the lower right of the GUI shows the relative strengths of the user's alpha, beta, gamma, delta, and theta brain waves. The GUI and Ganglion work together to separate and categorize brain waves based on characteristics like frequency and amplitude.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/headband-images/GUI_Ganglion.png?raw=true" width="30%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/headband-images/GUI_Ganglion.png" width="30%" />
 
 In the picture above, you can see the Ganglion Signal window in the lower left of the GUI. This widget helps users establish a quality connection for each electrode. For most bioelectrical measurements, you want the skin-electrode contact surface impedance to be low. Two of the four channels show lower impedance (these happen to be the flat snap electrodes that are touching the skin over the frontal cortex). This connection must be good, hence the green light to the left of the impedance value. If the impedance light in the GUI is red, you can improve the connection by making sure the electrodes are secured against the skin and making good contact. You may find it helpful to add a little [electrode paste](https://shop.openbci.com/products/ten20-conductive-paste-8oz-jar) to boost conductivity of the Ag-AgCl coating on the electrodes.
 
@@ -117,7 +115,7 @@ Another widget shown in the picture above is the Focus widget. When the alpha wa
 
 ## Headband-Cyton Tutorial
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/headband-images/Headband_Cyton_Front.JPG?raw=true" width="30%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/headband-images/Headband_Cyton_Front.JPG" width="30%" />
 
 The Cyton board supports eight channels of EEG/EMG/EEG input and streams data over [bluetooth](../../Cyton/03-Cyton_Data_Format.md). In this tutorial we will show you how to obtain three frontal lobe measurements and five temporal lobe measurements and stream the data over bluetooth!
 
@@ -131,7 +129,7 @@ Fully charge the Lithium Polymer Battery, until the charger's indicator LED turn
 
 #### Hardware
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/headband-images/Cyton_Headband_Pins.JPG?raw=true" width="30%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/headband-images/Cyton_Headband_Pins.JPG" width="30%" />
 
 As shown above:
 
@@ -158,7 +156,7 @@ As shown above:
 
 The placement of nodes on the headband is best represented in the following image:
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/headband-images/EEG%20Nodes_Updated_Cyton.png?raw=true" width="30%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/headband-images/EEG%20Nodes_Updated_Cyton.png" width="30%" />
 
 In this diagram, the red circles represent areas where flat electrodes can be placed, and the blue circles represent areas where comb electrodes can be placed. This placement is ultimately up to you, and the areas that you wish to record. However, a general suggestion for standard electrode placement is outlined in yellow.
 
@@ -168,7 +166,6 @@ To attach the electrodes to the headband:
 2.  Place the electrode on the soft side of the velcro
 3.  Snap the two pieces together, with the velcro in between, to secure them.
 
-   
 To attach the OpenBCI board onto the headband (for 0.5 meter variants):
 
 1. Snap the clip on the back of the clear board case (bottom half)
@@ -184,11 +181,11 @@ Now that you've finished with the hardware set-up, the next step is to set up th
 
 Once you've installed the GUI, fire it up [as shown in this YouTube video!](http://www.youtube.com/watch?v=XktF8OhHH4A)
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/headband_gui_cyton.jpeg?raw=true" width="30%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/headband_gui_cyton.jpeg" width="30%" />
 
 Play around with the vertical scale, filter, frequency range to see the effect on the raw data. The following screenshot shows an example of what your live-streamed brain data might look like.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/headband-images/GUI_Cyton_B.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/headband-images/GUI_Cyton_B.png" width="50%" />
 
 For more details on the various GUI functions, scroll up to the OpenBCI Software section of the Headband-Ganglion Tutorial above.
 
@@ -196,14 +193,13 @@ For cool project ideas, head over to the [**Example Projects**](https://docs.ope
 
 ## Use Cases for OpenBCI GUI
 
--   OpenBCI device owners want to visualize their brainwaves!
--   Many of the researchers, hackers and students alike who purchase OpenBCI devices want to use them to acquire data as soon as their device arrives.
--   Users use macOS, Windows and Linux to acquire data
--   Users want to filter incoming data in real time
--   Users want to make their own experiments to test their awesome theories or duplicate state of the art research at home!
--   Users struggle to get prerequisites properly installed to get data on their own from OpenBCI Cyton and Ganglion.
--   Users want to stream data into their own custom applications such as MATLAB.
-
+- OpenBCI device owners want to visualize their brainwaves!
+- Many of the researchers, hackers and students alike who purchase OpenBCI devices want to use them to acquire data as soon as their device arrives.
+- Users use macOS, Windows and Linux to acquire data
+- Users want to filter incoming data in real time
+- Users want to make their own experiments to test their awesome theories or duplicate state of the art research at home!
+- Users struggle to get prerequisites properly installed to get data on their own from OpenBCI Cyton and Ganglion.
+- Users want to stream data into their own custom applications such as MATLAB.
 
 ## Headband Tips and Signal Troubleshooting
 
@@ -217,22 +213,23 @@ Steps to fix RAILED error in the GUI Time Series widget:
 If you are seeing RAILED error, the default gain 24x may be too high for you. The optimal gain will vary depending on the individual user’s skin impedance.
 
 #### General suggestions
--   Moisten	a	Q-Tip	in	rubbing	alcohol,	and	scrub	the	surface	of	the	head	directly	underneath	the	contact	point	for	each	electrode.	This	will	remove	oil/debris	from	the	skin,	resulting	in	a	better	signal.		Then	place	the	headband	on	the	head,	with	the	center	electrode in	the	center	of	the	forehead.	
--   *Optional* - The flat and snap electrodes can be used with [electrode gel](https://shop.openbci.com/collections/frontpage/products/electrodegel). Inject electrode gel into the contact area using any standard small syringe. This will improve signal quality by lowering the skin-electrode impedance.
--   We recommend using a thin, flat tool to remove the flat snap electrodes. Un-snap it with the help of a thin screwdriver.
-  
+
+- Moisten a Q-Tip in rubbing alcohol, and scrub the surface of the head directly underneath the contact point for each electrode. This will remove oil/debris from the skin, resulting in a better signal. Then place the headband on the head, with the center electrode in the center of the forehead.
+- _Optional_ - The flat and snap electrodes can be used with [electrode gel](https://shop.openbci.com/collections/frontpage/products/electrodegel). Inject electrode gel into the contact area using any standard small syringe. This will improve signal quality by lowering the skin-electrode impedance.
+- We recommend using a thin, flat tool to remove the flat snap electrodes. Un-snap it with the help of a thin screwdriver.
+
 ## What You Can Do with OpenBCI GUI and Software Stack
 
--   Visualize data from every OpenBCI device: Ganglion, Cyton, CytonDaisy.
--   Playback files using GUI.
--   [Download](https://www.openbci.com/downloads) as a native application on macOS, Windows, and Linux.
--   Apply [filters](../../Software/OpenBCISoftware/02_GUI_Widget_Guide.md#filters) and other data processing tools to quickly clean raw data in real time.
--   Use the GUI as a [networking system](../../Software/OpenBCISoftware/02_GUI_Widget_Guide.md#networking) to move data out of GUI into other apps over UDP, OSC, LSL, and Serial.
--   Send data to [MATLAB](../../Software/CompatibleThirdPartySoftware/01-Matlab.md), Neuropype (using LSL), and other [third-party softwares.](../../Software/SoftwareLanding.md)
--   Analyze data with [Python and Brainflow](../../ForDevelopers/01-SoftwareDevelopment.md#brainflow---python)
--   [Create a widget framework](../../Software/OpenBCISoftware/02_GUI_Widget_Guide.md#custom-widget) that allows users to create their own experiments.
--   Output data into a saved file (file format .txt, .csv, .bd/.edf) for later offline processing.
--   [Customize the layout](../../Software/OpenBCISoftware/01-OpenBCI_GUI.md#customize-your-layout), change the gain, toggle on/off, check impedance of individual channels of the CytonDaisy board (or any connected OpenBCI board) directly in the GUI!
--   Access built-in widgets such as Focus Widget, Band Power, Accelerometer, EEG Head Plot, and MUCH more
+- Visualize data from every OpenBCI device: Ganglion, Cyton, CytonDaisy.
+- Playback files using GUI.
+- [Download](https://www.openbci.com/downloads) as a native application on macOS, Windows, and Linux.
+- Apply [filters](../../Software/OpenBCISoftware/02_GUI_Widget_Guide.md#filters) and other data processing tools to quickly clean raw data in real time.
+- Use the GUI as a [networking system](../../Software/OpenBCISoftware/02_GUI_Widget_Guide.md#networking) to move data out of GUI into other apps over UDP, OSC, LSL, and Serial.
+- Send data to [MATLAB](../../Software/CompatibleThirdPartySoftware/01-Matlab.md), Neuropype (using LSL), and other [third-party softwares.](../../Software/SoftwareLanding.md)
+- Analyze data with [Python and Brainflow](../../ForDevelopers/01-SoftwareDevelopment.md#brainflow---python)
+- [Create a widget framework](../../Software/OpenBCISoftware/02_GUI_Widget_Guide.md#custom-widget) that allows users to create their own experiments.
+- Output data into a saved file (file format .txt, .csv, .bd/.edf) for later offline processing.
+- [Customize the layout](../../Software/OpenBCISoftware/01-OpenBCI_GUI.md#customize-your-layout), change the gain, toggle on/off, check impedance of individual channels of the CytonDaisy board (or any connected OpenBCI board) directly in the GUI!
+- Access built-in widgets such as Focus Widget, Band Power, Accelerometer, EEG Head Plot, and MUCH more
 
 As always, don't hesitate to email us at [support@openbci.com](mailto:support@openbci.com) for assistance!

--- a/website/docs/AddOns/Headwear/04-Electrode_Cap_Tutorial.md
+++ b/website/docs/AddOns/Headwear/04-Electrode_Cap_Tutorial.md
@@ -10,7 +10,7 @@ You can pair the the Electrode Cap with the OpenBCI [CytonDaisy 16-channel Biose
 or a bioamplifier of your choice. Electrode gel must be used with the electrode cap.
 
 The placement of these electrodes is shown in the 10-20 diagram below:
-<img src="https://github.com/OpenBCI/Documentation/blob/master/website/docs/assets/HeadwareImages/electrode_cap_diagram_1020.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/OpenBCI/Documentation/master/website/docs/assets/HeadwareImages/electrode_cap_diagram_1020.png" width="50%" />
 
 The Electrode Cap comes in two variants:
 
@@ -35,11 +35,11 @@ the Electrode Cap is a low-cost, research-grade tool for obtaining 16 channels o
 
 Use the [y-splitter cable](../../../GettingStarted/Boards/DaisyGS/#2-y-splitter-cable) that came with your CytonDaisy to "gang" together the bottom SRB pins on the Cyton and the Daisy module, as shown below. This will be the reference electrode for the other electrodes on the subject's head.
 
-<img src="https://github.com/OpenBCI/Documentation/blob/master/website/docs/assets/GettingStartedImages/cytonDaisy_ySplitter_on_SRBpins.jpg?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/OpenBCI/Documentation/master/website/docs/assets/GettingStartedImages/cytonDaisy_ySplitter_on_SRBpins.jpg" width="50%" />
 
 Connect a HPTA cable to the single end of the y-splitter cable, then connect the its blue termination to the REF electrode of the cap, shown below.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/cap_ref_pin.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/cap_ref_pin.png" width="50%" />
 
 ![electrode cap reference](../../assets/HeadwareImages/eeg-electrode-cap-5.jpg)
 
@@ -53,7 +53,7 @@ Connect bottom pins N1P through N8P on the Daisy module to another set of HPTA c
 
 Connect a leftover HPTA cable to the bottom BIAS pin of the Cyton. The BIAS pin is used for noise cancelling. It is similar to a GROUND pin, which establishes a common ground between the Cyton board and your body, but it has some extra destructive interference noise cancelling techniques built in! Connect the blue termination of this HPTA cable to the GND cap electrode, shown below.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/cap_GND_pin.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/cap_GND_pin.png" width="50%" />
 
 For WHY these connections are recommended, see the [EEG explanation](../../GettingStarted/Biosensing-Setups/01-EEG-Setup.md)page.
 
@@ -81,7 +81,7 @@ Channels 9-16 on the GUI correspond to bottoms pins N1P through N8P on the Daisy
 
 ### Software
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/GUI-V4-Screenshot.jpg?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/GUI-V4-Screenshot.jpg" width="50%" />
 
 Head over to the OpenBCI GUI [tutorial](../../Software/OpenBCISoftware/01-OpenBCI_GUI.md) to set up your free live-streaming software!
 

--- a/website/docs/Examples/EMGProjects/01-EMG_Scrolling.md
+++ b/website/docs/Examples/EMGProjects/01-EMG_Scrolling.md
@@ -2,6 +2,7 @@
 id: EMGscrolling
 title: EMG Scrolling
 ---
+
 In this tutorial, we will show you how to scroll up and down on your computer screen without touching the keyboard. For that, we will read the peaks in EMG signals your arm muscles produce when you flex them and use them to scroll.
 
 Check out an example video of this tutorial being put into action!
@@ -25,14 +26,14 @@ Follow the EMG Getting Started [tutorial](GettingStarted/Biosensing-Setups/02-EM
 
 Download and install [Python](https://www.python.org/downloads/) (either version 2 or 3). Python might already be installed on your computer. Type python --version to check if you have Python version 2 or 3 installed. To use this program, you need the following Python packages installed:
 
--   **pylsl** : use `python -m pip install pylsl` from the Python folder in the command line to install it.
--   **pyautogui** : use `python -m pip install pyautogui` to install it.
+- **pylsl** : use `python -m pip install pylsl` from the Python folder in the command line to install it.
+- **pyautogui** : use `python -m pip install pyautogui` to install it.
 
 ## Step 3: Data Stream using the GUI.
 
 Follow the networking [tutorial](Software/OpenBCISoftware/02_GUI_Widget_Guide.md#networking) to learn how to stream data using LSL from the GUI. For this project, you will need to stream the EMG data using the Networking Widget. Your Networking settings should look as follows:
 
-<img src="https://github.com/OpenBCI/Documentation/blob/master/website/docs/assets/TutorialImages/EMG_Scrolling_GUI.png?raw=true" width="100%" />
+<img src="https://raw.githubusercontent.com/OpenBCI/Documentation/master/website/docs/assets/TutorialImages/EMG_Scrolling_GUI.png" width="100%" />
 
 :::info
 **Important:** Make sure your EMG widget is open before you start streaming.

--- a/website/docs/Examples/EMGProjects/04-EMG_LED.md
+++ b/website/docs/Examples/EMGProjects/04-EMG_LED.md
@@ -2,6 +2,7 @@
 id: EMG_LED
 title: EMG-controlled LED
 ---
+
 This tutorial is little more involved than the other EMG tutorials. No fear, we've documented every step below. Happy bio-hacking!
 
 In this tutorial, we will show you how to change the color of an LED depending on your facial expression. To do that, we will read the peaks in EMG signals your face muscles produce when you flex them and use them to change the color of an LED. The yellow color will indicate smiling, the red color frowning, and the blue color a neutral expression.
@@ -14,26 +15,26 @@ The following instructions have been written for use with Windows 10.
 
 ## Materials Required
 
--   Computer or Laptop with [OpenBCI GUI](Software/OpenBCISoftware/01-OpenBCI_GUI.md)
--   [Cyton Board](https://shop.openbci.com/products/cyton-biosensing-board-8-channel?variant=38958638542)
--   [Arduino UNO or equivalent](https://store.arduino.cc/usa/arduino-uno-rev3)
--   [Gold Cup Electrodes](https://shop.openbci.com/collections/frontpage/products/openbci-gold-cup-electrodes?variant=9056028163)
--   [Ten20 Conductive Paste](https://shop.openbci.com/products/ten20-conductive-paste-8oz-jar)
--   USB Cable
--   Blue, Red and Yellow LEDs - the number varies depending on the intensity
--   150 and 100 Ohm Resistors
--   3 NPN Transistors (one per color) such as the [2N2222](https://en.wikipedia.org/wiki/2N2222)
--   Breadboard with Jumper Wires
+- Computer or Laptop with [OpenBCI GUI](Software/OpenBCISoftware/01-OpenBCI_GUI.md)
+- [Cyton Board](https://shop.openbci.com/products/cyton-biosensing-board-8-channel?variant=38958638542)
+- [Arduino UNO or equivalent](https://store.arduino.cc/usa/arduino-uno-rev3)
+- [Gold Cup Electrodes](https://shop.openbci.com/collections/frontpage/products/openbci-gold-cup-electrodes?variant=9056028163)
+- [Ten20 Conductive Paste](https://shop.openbci.com/products/ten20-conductive-paste-8oz-jar)
+- USB Cable
+- Blue, Red and Yellow LEDs - the number varies depending on the intensity
+- 150 and 100 Ohm Resistors
+- 3 NPN Transistors (one per color) such as the [2N2222](https://en.wikipedia.org/wiki/2N2222)
+- Breadboard with Jumper Wires
 
 ## Step 1: Hardware Assembly
 
 For this project you will need five gold cup electrodes. Connect the first electrode cable to the bottom AGND pin, and the other _four_ electrode cables to the top and bottom pins of Channel 1 (**N1P**) and Channel 2 (**N2P**), as shown on the picture below.
 
-<img src="https://github.com/OpenBCI/Documentation/blob/master/website/docs/assets/TutorialImages/Facial_EMG_Cyton.png?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/OpenBCI/Documentation/master/website/docs/assets/TutorialImages/Facial_EMG_Cyton.png" width="70%" />
 
 Now it’s time to connect the electrodes to your body. To connect a gold cup electrode to your skip, apply some Ten20 paste on it like shown on the picture below, and stick it to your skin. To secure the connection, you can put some medical tape over it.
 
-<img src="https://github.com/OpenBCI/Documentation/blob/master/website/docs/assets/TutorialImages/Ten20.png?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/OpenBCI/Documentation/master/website/docs/assets/TutorialImages/Ten20.png" width="70%" />
 
 Now connect the five electrodes as shown on the picture below. The two electrodes on top of your eyebrow go to top and bottom N2P pins on the Cyton, the two electrodes closest to your mouth go to top and bottom N1P pins, and the electrode closest to your ear goes to bottom AGND. You can also use the color of the wires as a guide to know which electrode goes where.
 
@@ -49,7 +50,7 @@ Now connect the five electrodes as shown on the picture below. The two electrode
 
 <br />
 
-<img src="https://github.com/OpenBCI/Documentation/blob/master/website/docs/assets/TutorialImages/Facial_EMG_Positions.jpeg?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/OpenBCI/Documentation/master/website/docs/assets/TutorialImages/Facial_EMG_Positions.jpeg" width="70%" />
 
 <br />
 
@@ -58,19 +59,19 @@ LEDs to the Arduino for each color. The connections are shown on the diagram bel
 
 Finally, the LED gets connected to the Emitter pin of the transistor and to the Arduino pin GND through a resistor. In this way, the transistor acts as a switch to turn ON/OFF the group of LEDs while protecting the Arduino pin from receiving too much current.
 
-<img src="https://github.com/OpenBCI/Documentation/blob/master/website/docs/assets/TutorialImages/Facial_EMG_Diagram.png?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/OpenBCI/Documentation/master/website/docs/assets/TutorialImages/Facial_EMG_Diagram.png" width="70%" />
 
 The diagram above needs to be replicated for every color, with as many LEDs as you like. An example breadboard set-up is shown below.
 
-<img src="https://github.com/OpenBCI/Documentation/blob/master/website/docs/assets/TutorialImages/LED_Panels.jpeg?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/OpenBCI/Documentation/master/website/docs/assets/TutorialImages/LED_Panels.jpeg" width="70%" />
 
 ## Step 2: Arduino Setup
 
 The first step is to download the Arduino IDE from [here](https://www.arduino.cc/en/main/software). Once you have downloaded and installed the Arduino IDE, you should see a screen like the one below.
 
-<img src="https://github.com/OpenBCI/Documentation/blob/master/website/docs/assets/TutorialImages/init_arduino_pic.png?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/OpenBCI/Documentation/master/website/docs/assets/TutorialImages/init_arduino_pic.png" width="70%" />
 
-Download the folder with the code from [here](https://github.com/OpenBCI/OpenBCI_Tutorials/tree/master/Facial_EMG_Multiple_LEDs) and open it using the Arduino IDE by clicking on File &gt;&gt; Open... and selecting the entire folder.  Connect the Arduino to the computer by clicking on **Tools**, then selecting the right Board and Port options. Next, click on Upload and wait for the code to be uploaded.
+Download the folder with the code from [here](https://github.com/OpenBCI/OpenBCI_Tutorials/tree/master/Facial_EMG_Multiple_LEDs) and open it using the Arduino IDE by clicking on File &gt;&gt; Open... and selecting the entire folder. Connect the Arduino to the computer by clicking on **Tools**, then selecting the right Board and Port options. Next, click on Upload and wait for the code to be uploaded.
 
 Once the code has been loaded into the Arduino, open the Serial Monitor in the Arduino IDE and try sending the commands ‘Y’, ‘G’, and ‘B’ to the Arduino. The LED color should change to Red, Green and Blue respectively if everything is correct. After testing, close the Serial Monitor.
 
@@ -80,14 +81,14 @@ Once the code has been loaded into the Arduino, open the Serial Monitor in the A
 
 Download and install Python (either version 2 or 3). Python might already be installed on your computer. Type python --version to check if you have Python version 2 or 3 installed. To use this program, you need the following Python packages installed:
 
--   **pylsl**: use `python -m pip install pylsl` from the Python folder in the command line to install it.
--   **serial**: use `python -m pip install serial` to install it.
+- **pylsl**: use `python -m pip install pylsl` from the Python folder in the command line to install it.
+- **serial**: use `python -m pip install serial` to install it.
 
 ## Step 4: Stream data using the GUI
 
 Follow the Networking [Tutorial](Software/OpenBCISoftware/02_GUI_Widget_Guide.md#networking) to learn how to stream data using LSL from the GUI. For this project, you will need to stream the EMG data from Channels 1 and 2 using the Networking Widget. Your Networking settings should look as follows:
 
-<img src="https://github.com/OpenBCI/Documentation/blob/master/website/docs/assets/TutorialImages/EMG_Facial_GUI.png?raw=true" width="100%" />
+<img src="https://raw.githubusercontent.com/OpenBCI/Documentation/master/website/docs/assets/TutorialImages/EMG_Facial_GUI.png" width="100%" />
 
 :::info
 **Important**: Make sure your EMG widget is open before you start streaming.
@@ -95,7 +96,7 @@ Follow the Networking [Tutorial](Software/OpenBCISoftware/02_GUI_Widget_Guide.md
 
 ## Step 5: Using a Python Script to Send Data to the Arduino
 
-The Python script will search for the EMG data streams. Once it finds them it will read it and detect any spikes that correspond to the face muscle flexing. If a flex is detected and 10 milliseconds have passed since the last flex, it will send the corresponding letter ‘R’, ‘Y’ or ‘B’ depending on which gesture was detected.  The threshold for the time between flexes can be modified as needed to avoid debouncing.
+The Python script will search for the EMG data streams. Once it finds them it will read it and detect any spikes that correspond to the face muscle flexing. If a flex is detected and 10 milliseconds have passed since the last flex, it will send the corresponding letter ‘R’, ‘Y’ or ‘B’ depending on which gesture was detected. The threshold for the time between flexes can be modified as needed to avoid debouncing.
 
 Get the Python script from [here](https://github.com/OpenBCI/OpenBCI_Tutorials/tree/master/Facial_EMG_Multiple_LEDs) by clicking on ‘Raw’ and copying it to a .py file in your Python folder. Once you’re streaming data from the GUI, go to the folder that you stored the script in from your command line, and run it using `python.exe <script_name>.py`
 

--- a/website/docs/GettingStarted/Boards/01-Cyton_Getting_Started_Guide.md
+++ b/website/docs/GettingStarted/Boards/01-Cyton_Getting_Started_Guide.md
@@ -7,7 +7,7 @@ This guide will walk you through setting up your computer to use the Cyton and U
 
 ## I. What You Need
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Contents8bit.png?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Contents8bit.png" width="70%" />
 
 1.  OpenBCI Cyton Board
 2.  OpenBCI Dongle
@@ -17,19 +17,19 @@ This guide will walk you through setting up your computer to use the Cyton and U
 
 ### 1. Your Board
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/8.jpg?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/8.jpg" width="70%" />
 
 This tutorial can be followed if you are working with any Cyton board (8-bit, Cyton, or Cyton with Daisy). I'll be working with the 8-bit board.
 
 ### 2. Your OpenBCI USB Dongle
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/dongle.png?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/dongle.png" width="70%" />
 
 The OpenBCI USB Dongle has an integrated RFDuino that communicates with the RFDuino on the Cyton board. The dongle establishes a serial connection with your computer's on-board FTDI chip. The serial port is called /dev/tty\* (if you're using Linux or Mac) or COM\* (if you're using Windows). You'll be connecting to this serial port from the OpenBCI GUI or whatever other software you want to end up using to interface your Cyton board.
 
 ### 3. OpenBCI Gold Cup Electrodes and Electrode Paste
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/electrodeStarterKit.png?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/electrodeStarterKit.png" width="70%" />
 
 If you ordered an OpenBCI Gold Cup Electrodes and Ten20 Paste you should have:
 
@@ -38,7 +38,7 @@ If you ordered an OpenBCI Gold Cup Electrodes and Ten20 Paste you should have:
 
 If you plan to work with your own electrodes, the [touch-proof adapter](https://shop.openbci.com/products/touch-proof-electrode-cable-adapter) may come in handy:
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/touch_proof.jpg?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/touch_proof.jpg" width="70%" />
 
 It will convert any electrode that terminates in the industry-standard touch-proof design to an electrode that can be plugged into any OpenBCI Board!
 
@@ -52,7 +52,7 @@ Fully charge the Lithium Polymer Battery, until the charger's indicator LED turn
 
 Pre-2023:
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/batteryConnection.png?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/batteryConnection.png" width="70%" />
 
 Cyton boards have specific input voltage ranges. These input voltage ranges can be found on the back-side of the board, next to the power supply. **BE VERY CAREFUL** to not supply your board with voltages above these ranges, or else you will damage your board's power supply. For this reason, we recommend that you always use the battery pack that came with your OpenBCI kit.
 
@@ -68,8 +68,7 @@ Recommended: use the clear case that comes with your board.
 If you do not have a board case, your Cyton kit comes with 4 plastic feet that can be snapped into the holes of your board to provide extra stability while working.
 The case and plastic feet cannot be used at the same time.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/8bitboard_wPlasticFeet.png?raw=true" width="70%" />
-
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/8bitboard_wPlasticFeet.png" width="70%" />
 
 ## II. Download/Install/Run the OpenBCI GUI
 
@@ -81,7 +80,7 @@ Come back to this guide when your GUI is running!
 
 ### 1. Plug in your OpenBCI USB Dongle
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/dongleConnection.png?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/dongleConnection.png" width="70%" />
 
 Plug this in (facing upwards!) and you should see a blue LED light up and stay on, as well as a red LED **blink**.
 
@@ -89,13 +88,13 @@ Plug this in (facing upwards!) and you should see a blue LED light up and stay o
 
 ### 2. Plug in your Lithium Polymer Battery (or 6V AA battery pack (with batteries)
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/batteryConnection.png?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/batteryConnection.png" width="70%" />
 
 Cyton boards have specific input voltage ranges. These input voltage ranges can be found on the back-side of the board, next to the power supply. **BE VERY CAREFUL** to not supply your board with voltages above these ranges, or else you will damage your board's power supply. For this reason, we recommend that you always use the battery pack that came with your OpenBCI kit. There's a good reason we put this notice in here twice!
 
 ### 3. Switch your Cyton board to PC (not OFF or BLE)
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/PowerUpBoard.JPG?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/PowerUpBoard.JPG" width="70%" />
 
 Make sure to move the small switch on the right side of the board from "OFF" to "PC". As soon as you do, you should see a blue LED turn on. If you don't, press the reset (RST) button just to the left of the switch. If the LED still does not turn on, make sure you have full battery. If you're sure your batteries are fully charged, consult the [hardware section](https://openbci.com/forum/index.php?p=/categories/cyton) of our Forum.
 
@@ -105,7 +104,7 @@ Make sure to move the small switch on the right side of the board from "OFF" to 
 
 ### 1. Select LIVE (from Cyton)
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/serial_cyton_select_cyton.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/serial_cyton_select_cyton.png" width="50%" />
 
 In order to connect to your Cyton, you must specify the data source to be `LIVE (from Cyton)` in the first section of the System Control Panel. Before hitting the `START SYSTEM` button, you need to configure your Cyton board (follow the steps below).
 
@@ -113,13 +112,13 @@ In order to connect to your Cyton, you must specify the data source to be `LIVE 
 
 Next select `Serial (from Dongle)`.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/serial_cyton_select_serial.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/serial_cyton_select_serial.png" width="50%" />
 
 ### 3. Find your USB Dongle's Serial/COM port
 
 In the first section of the LIVE (from Cyton) sub-panel, find your Dongle's Serial/COM port name. If you're using a Mac or Linux, its name will be in the following format:
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/serial_cyton_select_serial_port.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/serial_cyton_select_serial_port.png" width="50%" />
 
 **/dev/tty\***
 
@@ -136,7 +135,7 @@ If you're still having trouble finding your USB Dongle's port name, refer to the
 
 ### 4. Select your channel count (8 or 16)
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/channelCount.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/channelCount.png" width="50%" />
 
 The CHANNEL COUNT setting is defaulted to 8. If you are working with an OpenBCI Daisy Module and Cyton board (16-channel) system, be sure to click the 16 CHANNELS button before starting your system.
 
@@ -148,34 +147,34 @@ The CHANNEL COUNT setting is defaulted to 8. If you are working with an OpenBCI 
 
 #### Check Status or Change Radio Channel
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/serial_cyton_open_radio_config.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/serial_cyton_open_radio_config.png" width="50%" />
 
 There is a Radio Configuration tab that you can use to check the status of your Cyton system and change the radio channel. Click on the `>` arrow to open up the options panel. Here you will find tools for configuring your Cyton Radio connection. Let's walk through the functions of each button.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/cyton_radio-status.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/cyton_radio-status.png" width="50%" />
 
 Click on the `STATUS` button to check the status of your Cyton system. This may take a few seconds to report, as it reaches out to your Dongle and Cyton board to verify that they are talking to each other. If they are, you will see the message `Success: System is Up`. If not, you will see `Failure: System is Down`.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/cyton_radio-get-channel.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/cyton_radio-get-channel.png" width="50%" />
 
 Click the `GET CHANNEL` button to know the channel that your Cyton system is communicating on. If the system is up, you will get the message `Success: Host and Device on Channel number: X`. If the system is down, you will get the message `Failure: Host on Channel number: X`.  
 **NOTE** the Host radio is on the Dongle, and the Device radio is on the Cyton board.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/cyton_change-channel.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/cyton_change-channel.png" width="50%" />
 
 Click on the `CHANGE CHANNEL` button to change the channel that your Cyton system is communicating on. This can be really useful if you have multiple Cyton systems in the same space. When you click the button, a menu will open up with the channels. When you click on the channel you want, it will take just a second, and you should get the message `Success: Host and Device on Channel number: X`.  
 **IMPORTANT** Make sure that there are not other Cytons active in the neighborhood when you change the channel!
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/cyton_override-dongle.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/cyton_override-dongle.png" width="50%" />
 
 Click on the `OVERRIDE DONGLE` button to change the channel of the OpenBCI Dongle only. When you click the button, a menu will open up with the channels. For the purpose of this Tutorial, go ahead and change the Dongle channel to Channel `15`. When you click on the channel number, it will take just a second, and you should get the message `Success: Host override - Channel number: 15`
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/cyton_status-failure.png?raw=true" width="50%" />
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/cyton_get-channel-failure.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/cyton_status-failure.png" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/cyton_get-channel-failure.png" width="50%" />
 
 Since you have just changed the channel of the Dongle only, When you click on the `STATUS` button, you will get a failure message. Similarly, when you press the `GET CHANNEL` button you will also get a failure message. But don't worry! We can use the Autoscan function to get your Cyton Board and Dongle back on the same track!
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/cyton_autoscan-success.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/cyton_autoscan-success.png" width="50%" />
 
 Now, click the `AUTOSCAN` button. It may take a few seconds for the Dongle to scan through every channel until it connects to your Cyton, but it will, and you will get the message `Success: System is Up` Autoscan!
 

--- a/website/docs/GettingStarted/Boards/011-Daisy_Getting_Started_Guide.md
+++ b/website/docs/GettingStarted/Boards/011-Daisy_Getting_Started_Guide.md
@@ -2,6 +2,7 @@
 id: DaisyGS
 title: Daisy Getting Started Guide
 ---
+
 This guide will walk you through getting 16-channel input on your Cyton+Daisy Module
 
 ## I. SET UP YOUR CYTON BOARD
@@ -19,42 +20,41 @@ Follow the guide through the end of Step V. CONNECT YOURSELF TO OPENBCI
 
 #### 1. [OpenBCI Daisy Module](https://shop.openbci.com/collections/frontpage/products/cyton-daisy-biosensing-boards-16-channel?variant=38959256526)
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Daisy%20Front%20Image.jpg?raw=true" width="60%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Daisy%20Front%20Image.jpg" width="60%" />
 
 #### 2. Y-Splitter Cable
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Daisy%20Y-Splitter%20Image.jpg?raw=true" width="60%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Daisy%20Y-Splitter%20Image.jpg" width="60%" />
 
 #### 3. Electrode Cables with female header termination on one end
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Daisy%20Female%20Header%20Termination%20Image.jpg?raw=true" width="60%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Daisy%20Female%20Header%20Termination%20Image.jpg" width="60%" />
 
 ## III. ASSEMBLY
 
 ### 1) Attaching the Daisy
 
-
-####  Add the Daisy extension directly onto the Cyton Board
+#### Add the Daisy extension directly onto the Cyton Board
 
 Carefully stack the Daisy module on top of the Cyton Board, as shown below.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Cyton%2BDaisy%20Front%20Image.JPG?raw=true" width="60%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Cyton%2BDaisy%20Front%20Image.JPG" width="60%" />
 
 ### 2) Connect Y-Splitter Cable
 
-<img src="https://github.com/OpenBCI/Documentation/blob/master/website/docs/assets/GettingStartedImages/cytonDaisy_ySplitter_on_SRBpins.jpg?raw=true" width="60%" />
+<img src="https://raw.githubusercontent.com/OpenBCI/Documentation/master/website/docs/assets/GettingStartedImages/cytonDaisy_ySplitter_on_SRBpins.jpg" width="60%" />
 
 The Y-Splitter connects the bottom `SRB` pin of the Daisy Board to the bottom `SRB` pin of the Cyton Board. The single end of the Y-Splitter connects to a reference point i.e. the earlobe or mastoid bone.
 
 ### 3) Connect the bottom `BIAS` pin of the Cyton to a second reference point
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Cyton_Daisy_BIAS.jpg?raw=true" width="60%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Cyton_Daisy_BIAS.jpg" width="60%" />
 
 **Usually, the earlobe or mastoid is used as the reference point, because it has no muscle or neurons and therefore low electrical signals.**
 
 ### 4) Connect Cyton bottom pins `N1P-N8P` and Daisy bottom pins `N1P-N8P` to leads
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/MarkIV/Cyton_Daisy_Setup.JPG?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/MarkIV/Cyton_Daisy_Setup.JPG" width="80%" />
 
 Use the 16 of the color coded cables that came with your Ultracortex MarkIV headset. Alternatively, you can use 16 of our [Gold Cup Electrodes](https://shop.openbci.com/collections/frontpage/products/openbci-gold-cup-electrodes?variant=9056028163), [Snap Electrode Cables](https://shop.openbci.com/collections/frontpage/products/emg-ecg-snap-electrode-cables?variant=32372786958), or [Header Pin to Touch Proof Electrode Adapter](https://shop.openbci.com/collections/frontpage/products/touch-proof-electrode-cable-adapter?variant=31007211715).
 
@@ -62,5 +62,3 @@ Connect Cyton bottom pins `N1P` through `N8P` to the cables, shown above. Then, 
 For best results, when plugging female header pins onto the OpenBCI board, orient the sides with the 'silver latch bit' facing toward you since that side is a tiny bit wider than 0.1".
 
 Refer to the Ultracortex Mark IV [tutorial](../../AddOns/Headwear/01-Ultracortex-Mark-IV.md) to learn how to connect the male terminations of the color coded cables to the electrodes on the headset.
-
-

--- a/website/docs/Software/CompatibleThirdPartySoftware/01-Matlab.md
+++ b/website/docs/Software/CompatibleThirdPartySoftware/01-Matlab.md
@@ -2,6 +2,7 @@
 id: Matlab
 title: MATLAB
 ---
+
 [MATLAB](https://en.wikipedia.org/wiki/MATLAB) is a powerful numerical computing language and environment that is widely used in a wide variety of academic, research, and industrial applications.
 
 A few MATLAB toolboxes have been created specifically for working with EEG and BCI. [EEGLAB](http://sccn.ucsd.edu/eeglab/), [BCILAB](http://sccn.ucsd.edu/wiki/BCILAB), [ERPLAB](http://erpinfo.org/erplab), and [FieldTrip](http://www.fieldtriptoolbox.org/) are a few toolboxes that have helped OpenBCI users work in MATLAB.
@@ -51,7 +52,7 @@ This method is not the same as using OpenBCI CSV files. In BrainFlow CSV files, 
 
 - BrainFlow CSV File Example: `BrainFlow-RAW_2022-03-11_15-41-42_0.csv`
 - OpenBCI CSV File Example: `OpenBCI-RAW-2022-03-11_15-44-27.txt`
-:::
+  :::
 
 #### Use BrainFlow Python Script to Read/Write BrainFlow CSV File
 
@@ -68,15 +69,15 @@ This method is not the same as using BrainFlow CSV files. In OpenBCI CSV files, 
 
 - BrainFlow CSV File Example: `BrainFlow-RAW_2022-03-11_15-41-42_0.csv`
 - OpenBCI CSV File Example: `OpenBCI-RAW-2022-03-11_15-44-27.txt`
-:::
+  :::
 
 Import the CSV file into MATLAB as a matrix by using the "Import Data" wizard:
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/matlab_tutorial/matlab_import_data.png?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/matlab_tutorial/matlab_import_data.png" width="80%" />
 
 Select a saved OpenBCI data file. Once the data import screen is open, select the "Numeric Matrix" import option. Deselect all of the header rows. Also deselect the final column, the timestamp values, since the import wizard can only parse numeric values. Feel free to give your matrix a convenient name, like "eeg_data":
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/matlab_tutorial/matlab_import_screen.png?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/matlab_tutorial/matlab_import_screen.png" width="80%" />
 
 Click "Import Selection". Your matrix should now appear as an object in your workspace! Keep reading to learn more about processing your data with MATLAB toolboxes.
 
@@ -155,11 +156,11 @@ bcilab
 
 To start running BCILAB. After some console output, you should see the text "Welcome to the BCILAB toolbox!" and then a new GUI with the BCILAB menu should appear.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/Matlab/bcilab_menu.png?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/Matlab/bcilab_menu.png" width="80%" />
 
 Once a stream has been started on your computer, open BCILAB within MATLAB (>> cd your/path/to/bcilab; bcilab) and from the menu, select **Online Analysis > Read input from... > Lab streaming layer...**
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/Matlab/bcilab_lsl.png?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/Matlab/bcilab_lsl.png" width="80%" />
 
 ## Analyzing OpenBCI data
 
@@ -184,7 +185,7 @@ If the toolkit is not yet correctly implemented, the console should output:
 
 If it is set up correctly, a pop-up window should appear with the EEGLAB GUI.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/Matlab/eeglab_gui.jpg?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/Matlab/eeglab_gui.jpg" width="70%" />
 
 #### Preparing OpenBCI Datasets for EEGLAB Use
 
@@ -202,7 +203,7 @@ Your data matrix is now ready to use with EEGLAB.
 
 If EEGLAB isn't already running, enter "eeglab" into the MATLAB command line to start the program. Import your matrix into EEGLAB using the EEGLAB GUI: File -> Import Data -> Using EEGLAB functions and plugins -> From ASCII/float file or MATLAB array
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/Matlab/eeglab_dataimport.png?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/Matlab/eeglab_dataimport.png" width="80%" />
 
 In the pop-up window that appears, enter information about the data set. Select "MATLAB variable", and enter the name of the variable where your matrix is stored. Enter the Data Sampling rate (it should be commented in at the top of the text file - usually 250 Hz by default in the OpenBCI GUI). The other fields can be left at default, and EEGLAB will automatically fill in the information from the data set.
 
@@ -214,11 +215,11 @@ The data is now imported into EEGLAB and ready to use!
 
 To double-check your data is imported correctly, and to get familiar with EEGLAB's interface, try plotting your data. Select Plot -> Channel data (scroll) from the EEGLAB pop-up window.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/matlab_tutorial/EEGLAB_plot.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/matlab_tutorial/EEGLAB_plot.png" width="50%" />
 
 Your data should appear in a window like the image below:
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/matlab_tutorial/EEGLAB_plot_image.png?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/matlab_tutorial/EEGLAB_plot_image.png" width="80%" />
 
 Check out the links in the Further Reading section to learn more about processing data with EEGLAB!
 
@@ -228,7 +229,7 @@ From what we can tell, EEGLAB seems to work primarily with datasets and recorded
 
 ### ERPLAB
 
-From the [ERPLAB homepage](http://erpinfo.org/erplab): "ERPLAB Toolbox is a free, open-source MATLAB package for analyzing ERP data.  It is tightly integrated with EEGLAB Toolbox, extending EEGLAB’s capabilities to provide robust, industrial-strength tools for ERP processing, visualization, and analysis.  A graphical user interface makes it easy for beginners to learn, and MATLAB scripting provides enormous power for intermediate and advanced users."
+From the [ERPLAB homepage](http://erpinfo.org/erplab): "ERPLAB Toolbox is a free, open-source MATLAB package for analyzing ERP data. It is tightly integrated with EEGLAB Toolbox, extending EEGLAB’s capabilities to provide robust, industrial-strength tools for ERP processing, visualization, and analysis. A graphical user interface makes it easy for beginners to learn, and MATLAB scripting provides enormous power for intermediate and advanced users."
 
 #### Setup
 
@@ -236,7 +237,7 @@ From the [ERPLAB homepage](http://erpinfo.org/erplab): "ERPLAB Toolbox is a free
 
 Next time your launch EEGLAB, the ERPLAB menu should appear in the EEGLAB GUI:
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/Matlab/erplab.png?raw=true" width="70%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/Matlab/erplab.png" width="70%" />
 
 #### Analyzing EEG Data Sets
 

--- a/website/docs/Software/CompatibleThirdPartySoftware/02-Neuromore.md
+++ b/website/docs/Software/CompatibleThirdPartySoftware/02-Neuromore.md
@@ -2,6 +2,7 @@
 id: Neuromore
 title: Neuromore
 ---
+
 Neuromore is an EEG streaming and processing studio. Like BrainBay and BioEra, it provides a visual designer that can be used to process signals real-time.
 
 ## Setting Up Your Environment
@@ -20,7 +21,7 @@ Download the latest verison of Neuromore Studio for your operating system from t
 
 Open the Neuromore Studio application. A demo will begin playing that displays example EEG data.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Third_party_software/Neruomore_opening_screen.png?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Third_party_software/Neruomore_opening_screen.png" width="80%" />
 
 ## Livestream from OpenBCI to Neuromore
 
@@ -39,7 +40,7 @@ Rodrigos-MacBook-Pro:~ rodrigo$ ls /dev/tty.*
 
 Now, to connect to your OpenBCI board from within Neuromore, click the magnifying glass under "Devices" in the top right corner. This will prompt Neuromore to search for new devices. You should see an OpenBCI logo pop up, and data from your board will start streaming in the top of the Neuromore window.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Third_party_software/neuromore_openBCI_connected.png?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Third_party_software/neuromore_openBCI_connected.png" width="80%" />
 
 #### Troubleshooting
 
@@ -57,41 +58,41 @@ NOTE: If your board is connected properly, neuromore should have no trouble conn
 
 To get started with Neuromore, open the "Getting Started" classifier in the OpenBCI folder of the "Back-End File System" pane:
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/obci_gs_loc.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/obci_gs_loc.png" width="50%" />
 
 An example of Neuromore's visual programming language will appear. Click the wrench-and-screwdriver icon to hide the Node Palette pane if necessary.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Third_party_software/neuromore_getting_started.png?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Third_party_software/neuromore_getting_started.png" width="80%" />
 
 Neuromore calls these graphs of interconnected processing units "Classifiers". The basic structure of a classifer consists of a input device (such as OpenBCI V3) connected to processing nodes that end in some sort of output node.
 
 Some of the output nodes produce visual output, like graphs in the time or frequency domain. However, the default Neuromore Studio layout doesn't have windows open for those outputs. To add a window for time-domain outputs, click on the View tab of the toolbar, then Add -&gt; Signal View.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Third_party_software/neuromore_adding_signal_view.png?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Third_party_software/neuromore_adding_signal_view.png" width="50%" />
 
 A new window will appear. Click and drag the window to a convenient place in the Neuromore Studio Layout - it should snap into place, like below.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Third_party_software/neuromore_signal_view.png?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Third_party_software/neuromore_signal_view.png" width="80%" />
 
 If you look at the Classifier window, you will notice there are three "output" nodes (nodes with an eye symbol): Filtered Raw, Filtered FFT, and Viewer. The Filtered Raw and View symbols are time-domain, and are the two symbols in the Signal View.
 
 To add a window for frequency-domain outputs, click on View -&gt; Add -&gt; Spectrum View. Reposition the new window to a convenient place. You should see one signal, the Filtered FFT node.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Third_party_software/neuromore_spectrum_view.png?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Third_party_software/neuromore_spectrum_view.png" width="80%" />
 
 Want to double-check which signal corresponds to which output? Double click on one of the output nodes in the Classifier window. This should expand the Node Palette window. Display the Attributes tab and select "Custom Color". Double click on the block of color that appears to choose the color of your signal.
 
 In the example below, I selected the "Filtered Raw" node, and set the color to bright green. The corresponding signal is now bright green in the Signal View window.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/Third_party_software/neuromore_color_coded_signals.png?raw=true" width="80%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/Third_party_software/neuromore_color_coded_signals.png" width="80%" />
 
 Now you're able to view the signals from your output nodes in your Classifier!
 
-This sort of graphical programming (or [visual programming](https://en.wikipedia.org/wiki/Visual_programming_language)) also appears in very popular programs like [PureData](https://puredata.info/) and [MAX](https://en.wikipedia.org/wiki/Max_(software)/) for more general purposes and [OpenViBE](Software/CompatibleThirdPartySoftware/03-OpenViBE.md) and of course neuromore for EEG specific processing.
+This sort of graphical programming (or [visual programming](https://en.wikipedia.org/wiki/Visual_programming_language)) also appears in very popular programs like [PureData](https://puredata.info/) and [MAX](<https://en.wikipedia.org/wiki/Max_(software)>) for more general purposes and [OpenViBE](Software/CompatibleThirdPartySoftware/03-OpenViBE.md) and of course neuromore for EEG specific processing.
 
 The basic idea is that a stream of data that originates at the input device can then be mapped, processed and transformed into outputs that are useful, informative or just plain cool.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/alpha-detect-gs.png?raw=true" width="100%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/master/assets/images/alpha-detect-gs.png" width="100%" />
 
 The getting started example for OpenBCI in the neuromore Studio explores these areas and how to properly use the graphical programming interface.
 
@@ -107,8 +108,8 @@ From this example we can see the power of statistics and simple logic that can e
 
 ## Documentation and Resources
 
--   [neuromore.com](http://www.neuromore.com/)
--   [Video tutorials](https://www.youtube.com/channel/UCAOU6SsvwCwC30hJaFLhWgw)
--   [Graphical Programming](http://c2.com/cgi/wiki?GraphicalProgrammingLanguage)
+- [neuromore.com](http://www.neuromore.com/)
+- [Video tutorials](https://www.youtube.com/channel/UCAOU6SsvwCwC30hJaFLhWgw)
+- [Graphical Programming](http://c2.com/cgi/wiki?GraphicalProgrammingLanguage)
 
 Did you use Neuromore and OpenBCI to build something new? Post about it on our [forum!](https://openbci.com/forum/)

--- a/website/docs/Software/OpenBCISoftware/02_GUI_Widget_Guide.md
+++ b/website/docs/Software/OpenBCISoftware/02_GUI_Widget_Guide.md
@@ -112,7 +112,7 @@ As of GUI 5.0.9, use the new [Cyton Signal Widget](../OpenBCISoftware/02_GUI_Wid
 
 ## FFT Plot
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/GUI_FTT.jpg?raw=true" width="100%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/refs/heads/master/assets/images/GUI_FTT.jpg" width="100%" />
 
 This is a standard data visualization feature of biosensing tools. The x-axis displays various frequencies, and the y-axis shows each frequency’s respective amplitudes in μV. These amplitudes are displayed logarithmically by default — a recommended setting — but you can alter this in the "Log/Lin" dropdown.
 
@@ -128,7 +128,7 @@ In the picture below, you can see great Alpha Waves centered around 10 Hz using 
 
 ## Accelerometer
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/GUI_Accel.jpg?raw=true" width="100%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/refs/heads/master/assets/images/GUI_Accel.jpg" width="100%" />
 
 Each OpenBCI board is fitted with a three-axis accelerometer, the data from which is streamed to this widget. This accelerometer measures the acceleration of the board itself on an XYZ-axis.
 
@@ -187,11 +187,11 @@ Based off of 10-20 model
 
 When compared to a reference, the pin inputs can produce a positive or negative value. Choosing "+/-" will display the true value as measured from the reference. So if the voltage is measured as lower than the reference, your value will appear negative (or blue), and if the voltage is measured to be higher the value will be positive.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/GUI_Headplot_both.jpg?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/refs/heads/master/assets/images/GUI_Headplot_both.jpg" width="50%" />
 
 Alternatively, "+" will display only an absolute value, without regard to whether the signal was positive or negative.
 
-<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/GUI_Headplot_pos.jpg?raw=true" width="50%" />
+<img src="https://raw.githubusercontent.com/openbci-archive/Docs/refs/heads/master/assets/images/GUI_Headplot_pos.jpg" width="50%" />
 
 ## Spectrogram Widget
 


### PR DESCRIPTION
previous format was : `<img src="https://github.com/openbci-archive/Docs/blob/master/assets/images/8.jpg?raw=true" />`

using only ?raw=true and the github.com .../blob/ format pointed to GitHub's HTML interface, not directly to the raw file.

Now uses GitHub's raw file host directly. 