### PR TITLE
Fix markdown bold styling in issue #306

### DIFF
--- a/website/docs/Cyton/04-OpenBCI_Cyton_SDK.md
+++ b/website/docs/Cyton/04-OpenBCI_Cyton_SDK.md
@@ -49,7 +49,7 @@ These ASCII characters turn the respective channels [1-8] off. The channel will 
 
 ### Turn Channels ON
 
-**! @ # $ % ^ & \* **
+**! @ # $ % ^ & \***
 
 These ASCII characters turn the respective channels [1-8] on. The channel will read ADC output values during streamData mode. These commands work both in and out of streamData mode.
 


### PR DESCRIPTION
## Description
This PR fixes a minor Markdown rendering issue in `website/docs/Cyton/04-OpenBCI_Cyton_SDK.md`. 

Due to incorrect spacing, the bold text styling was broken, and the raw asterisks (`**`) were being displayed to the user instead of rendering the text in bold. 

## Changes Made
* Adjusted the syntax around the asterisks in `04-OpenBCI_Cyton_SDK.md` to ensure the bold format renders correctly.

## Related Issues
Closes #306