### PR TITLE
docs: expand battery charging instructions with connection details

### DIFF
--- a/website/docs/GettingStarted/Boards/01-Cyton_Getting_Started_Guide.md
+++ b/website/docs/GettingStarted/Boards/01-Cyton_Getting_Started_Guide.md
@@ -46,7 +46,7 @@ For best results, when plugging female header pins onto the OpenBCI board, orien
 
 ### 4. Your Lithium Polymer Battery and USB Charger (or 6V Battery Pack & 4 AA Batteries, pre-2023)
 
-Fully charge the Lithium Polymer Battery, until the charger's indicator LED turns green.
+Fully charge the Lithium Polymer Battery, until the charger's indicator LED turns green. To do this, insert the battery's white plug into the matching slot on the USB charger (shown on the right), and connect the charger into a USB port.
 
 ![lithium battery and USB charger](../../assets/GettingStartedImages/board_case_with_lithium_battery_and_charger.png)
 

--- a/website/docs/GettingStarted/Boards/02-Ganglion_Getting_Started_Guide.md
+++ b/website/docs/GettingStarted/Boards/02-Ganglion_Getting_Started_Guide.md
@@ -34,7 +34,7 @@ Plug the OpenBCI Ganglion Dongle into your computer before launching the GUI.
 
 ### 3. Your Lithium Polymer Battery and USB Charger (or 6V Battery Pack & 4 AA Batteries, pre-2023)
 
-Fully charge the Lithium Polymer Battery, until the charger's indicator LED turns green.
+Fully charge the Lithium Polymer Battery, until the charger's indicator LED turns green. To do this, insert the battery's white plug into the matching slot on the USB charger (shown on the right), and connect the charger into a USB port.
 
 ![lithium battery and USB charger](../../assets/GettingStartedImages/board_case_with_lithium_battery_and_charger.png)
 


### PR DESCRIPTION
## Overview
This PR improves the documentation in the **Getting Started** section for Cyton and Ganglion. 

It expands the battery charging instructions to clearly elaborate on how to connect the LiPo battery's white plug into the USB charger and plug it into a USB port.