### PR TITLE
Fix downloads link on FAQ page.

### DIFF
--- a/website/docs/FAQ/03-HardwareFAQ.md
+++ b/website/docs/FAQ/03-HardwareFAQ.md
@@ -25,4 +25,4 @@ With additional channels, you have greater spatial resolution. The Ganglion (the
 
 ## Where do I download the OpenBCI software?
 
-You can go to our [downloads page](http://openbci.com/donation)!
+You can go to our [downloads page](http://openbci.com/downloads)!


### PR DESCRIPTION
### Description
Fixed a bug on the FAQ page where the downloads link was incorrectly pointing to the donations page instead of the downloads section. 

### Changes
* Updated the URL for the downloads link in the FAQ documentation to point to the correct destination.