### PR TITLE
docs: clarify Cyton marker AUX1 wire format

### DIFF
--- a/website/docs/Cyton/04-OpenBCI_Cyton_SDK.md
+++ b/website/docs/Cyton/04-OpenBCI_Cyton_SDK.md
@@ -492,7 +492,7 @@ This works similarly to the sample rate. Power cycling the OpenBCI board will ca
 - 1 = Debug mode - Sends serial output over the external serial port which is helpful for debugging.
 - 2 = Analog mode - Reads from analog pins A5(D11), A6(D12), and A7(D13) as well.
 - 3 = Digital mode - Reads from analog pins D11, D12, D13, D17, and D18.
-- 4 = Marker mode - Turns accel off and injects markers into the stream by sending _\`X_ where `X` is any char to add to the first AUX byte.
+- 4 = Marker mode - Turns accel off and injects markers into the stream by sending _\`X_ where the value of `X` is stored in AUX1 (`auxData[0]`), a signed 16-bit integer serialized MSB-first into packet bytes 27–28 (the first two bytes of the six-byte AUX field). For example, a positive marker value of `0x28` is serialized as `00 28`.
 - / = Get current board mode
 
 **EXAMPLE**


### PR DESCRIPTION
The Cyton SDK currently describes marker mode as adding the marker character to the "first AUX byte." In the Cyton library, however, the marker is stored in `auxData[0]`, which is a signed 16-bit `short`, and raw-AUX serialization writes each AUX value MSB first.

For a positive marker value such as `0x28`, AUX1 is `0x0028`, so packet bytes 27–28 are serialized as `00 28`.

This PR updates only the marker-mode description to distinguish AUX1 (`auxData[0]`) from the first physical AUX wire byte and to state the packet positions and byte order explicitly. No firmware behavior is changed.

This is intentionally separate from #334, which addresses board-mode response examples rather than AUX1 wire representation.